### PR TITLE
Update login UI with dual pane layout

### DIFF
--- a/src/css/style.css
+++ b/src/css/style.css
@@ -82,6 +82,42 @@ input:disabled{ background: #F0F0F0}
 .menbership a::after{content: "|";font-size: 10px;margin:0 5px 0 15px;position: relative;top: -1px; color: #333333;}
 .menbership a:last-child:after{ content: "";}
 
+/* Login page layout */
+.login-page {
+  display: flex;
+  height: 100vh;
+}
+
+.login-form {
+  flex: 1;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.login-info {
+  flex: 1;
+  background-color: #0a1929;
+  color: #ffffff;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  text-align: center;
+  padding: 20px;
+}
+
+.login-info h1 {
+  font-size: 2rem;
+  margin-bottom: 1rem;
+}
+
+.login-info p {
+  max-width: 400px;
+  font-size: 1rem;
+  opacity: 0.8;
+}
+
 /* loading*/
 .loadbar em{display: none; z-index: 2; text-align: center; position: absolute; width: 100%; font-size: 24px; font-weight: 600; color: #ffffff; text-shadow: 1px 1px 2px rgba(0, 0, 0, 0.9); line-height: 50px; letter-spacing: 1px;}
 .loadbar.on em{ display: block}
@@ -102,6 +138,14 @@ input:disabled{ background: #F0F0F0}
   .sample_site li a{ width: 100%;}
   .modal_bg {position: fixed;}
   .login_article {width: 90%;}
+  .login-page {
+    flex-direction: column;
+  }
+  .login-form,
+  .login-info {
+    width: 100%;
+    height: auto;
+  }
 }
 
 

--- a/src/pages/Login/Login.js
+++ b/src/pages/Login/Login.js
@@ -780,8 +780,10 @@ const passwordlessCheckID = async (QRReg) => {
 	};   
 
     return (
-      <div className="main_container">
-      <div className="modal">
+      <div className="login-page">
+        <div className="login-form">
+          <div className="main_container">
+            <div className="modal">
         <div style={{ width: '100%', textAlign: 'right' }}>
           <div className="select_lang">
           <select id="lang" name="lang" value={sessionStorage.getItem("language")} onChange={(e) => common.changeLanguage(e.target.value)}>
@@ -1060,7 +1062,16 @@ const passwordlessCheckID = async (QRReg) => {
         </div>
       </div>
     </div>
-    
+    <div className="login-info">
+      <h1>Welcome to<br />our community</h1>
+      <p>
+        Fuse helps developers to build organized and well coded dashboards full of
+        beautiful and rich modules. Join us and start building your application
+        today.
+      </p>
+    </div>
+  </div>
+
     );
 }
 


### PR DESCRIPTION
## Summary
- redesign login screen with a two column layout
- add dark blue welcome panel with headline text
- update responsive styles

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68661bd07f14832b89ad70245e65011d