### PR TITLE
Add Dockerfile for collify

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+node_modules
+build
+.git
+.gitignore
+Dockerfile
+.dockerignore
+Archivo.zip

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,27 @@
+# Use official Node.js image to build the React app
+FROM node:18-alpine AS build
+
+# Create app directory
+WORKDIR /app
+
+# Install dependencies
+COPY package*.json ./
+RUN npm install
+
+# Copy source code
+COPY . .
+
+# Build the React application
+RUN npm run build
+
+# Use Nginx to serve the built app
+FROM nginx:alpine
+
+# Copy build output to Nginx HTML directory
+COPY --from=build /app/build /usr/share/nginx/html
+
+# Expose port 80
+EXPOSE 80
+
+# Start Nginx server
+CMD ["nginx", "-g", "daemon off;"]


### PR DESCRIPTION
## Summary
- add Dockerfile for building and serving the React app via Nginx
- ignore development directories and files in `.dockerignore`

## Testing
- `npm test --silent -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866b2bc466c832bb542a9dea6584c08